### PR TITLE
Fixed issue when running dev/build

### DIFF
--- a/code/RootURLControllerExtension.php
+++ b/code/RootURLControllerExtension.php
@@ -16,15 +16,17 @@ class RootURLControllerExtension extends Extension
      */
     public function updateHomePageLink(&$link)
     {
-        $host = str_replace('www.', null, $_SERVER['HTTP_HOST']);
-        $candidates = SiteTree::get()->where(array(
-            '"SiteTree"."HomepageForDomain" LIKE ?' => "%$host%"
-        ));
-        if ($candidates) {
-            /** @var SiteTree $candidate */
-            foreach ($candidates as $candidate) {
-                if (preg_match('/(,|^) *' . preg_quote($host) . ' *(,|$)/', $candidate->HomepageForDomain)) {
-                    $link = trim($candidate->RelativeLink(true), '/');
+        if (isset($_SERVER['HTTP_HOST'])) {
+            $host = str_replace('www.', null, $_SERVER['HTTP_HOST']);
+            $candidates = SiteTree::get()->where(array(
+                '"SiteTree"."HomepageForDomain" LIKE ?' => "%$host%"
+            ));
+            if ($candidates) {
+                /** @var SiteTree $candidate */
+                foreach ($candidates as $candidate) {
+                    if (preg_match('/(,|^) *' . preg_quote($host) . ' *(,|$)/', $candidate->HomepageForDomain)) {
+                        $link = trim($candidate->RelativeLink(true), '/');
+                    }
                 }
             }
         }


### PR DESCRIPTION
When running dev/build, both locally and when attempting to deploy, i was getting this error:
```
ERROR [Notice]: Undefined index: HTTP_HOST
IN GET dev/build
Line 19 in /home/makreig/Projects/greenman-web/vendor/twohill/silverstripe-homepagefordomain/code/RootURLControllerExtension.php

Source
======
  10:  
  11:      /**
  12:       * Get the full form (e.g. /home/) relative link to the home page for the current HTTP_HOST
       value. Note that the
  13:       * link is trimmed of leading and trailing slashes before returning to ensure consistency.
  14:       *
  15:       * @param string $link
  16:       */
  17:      public function updateHomePageLink(&$link)
  18:      {
* 19:          $host = str_replace('www.', null, $_SERVER['HTTP_HOST']);
  20:          $candidates = SiteTree::get()->where(array(
  21:              '"SiteTree"."HomepageForDomain" LIKE ?' => "%$host%"
  22:          ));
  23:          if ($candidates) {
  24:              /** @var SiteTree $candidate */
  25:              foreach ($candidates as $candidate) {
```

Added check to ensure that $_server['HTTP_HOST'] is set before updating the link.