### PR TITLE
Fix for PHP 8.1 Deprecation

### DIFF
--- a/code/RootURLControllerExtension.php
+++ b/code/RootURLControllerExtension.php
@@ -16,7 +16,7 @@ class RootURLControllerExtension extends Extension
      */
     public function updateHomepageLink(&$link)
     {
-        $host = str_replace('www.', null, $_SERVER['HTTP_HOST']);
+        $host = str_replace('www.', '', $_SERVER['HTTP_HOST']);
         $candidates = SiteTree::get()->where([
             '"SiteTree"."HomepageForDomain" LIKE ?' => "%$host%"
         ]);


### PR DESCRIPTION
Fixes `[Deprecated] str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated`.